### PR TITLE
clarify test FAQ

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -309,8 +309,8 @@
           </details>
 
           <details class="FAQItem" id="how-does-the-test-work">
-            <summary><span>How does the test work?</span></summary>
-            <p>In order to test if your ISP is implementing BGP safely, we announce a legitimate route but we make sure the announcement is <em>invalid</em>. If you can load the website we host on that route, that means the invalid route was accepted by your ISP. A leaked or a hijacked route would likely be accepted too.</p>
+            <summary><span>Can I test whether my ISP supports RPKI?</span></summary>
+            <p>In order to test if your ISP is implementing BGP safely, we announce a legitimate route but we make sure the announcement is <em>invalid</em>. If you can load the website we host on that route, that means the invalid route was accepted by your ISP. A leaked or a hijacked route would likely be accepted too. To verify whether your ISP supports RPKI, hit 'Test your ISP' at the top of this website.</p>
           </details>
 
           <details class="FAQItem" id="can-even-more-be-done">


### PR DESCRIPTION
Some people may browse past the "Test your ISP" button at the top of the
site. This commit makes the FAQ related to the test a bit more generic
so that it can be read in a vacuum.