### PR TITLE
operators: Add TDC and Hi3G as unsafe

### DIFF
--- a/public/data/operators.csv
+++ b/public/data/operators.csv
@@ -11,11 +11,13 @@ TATA,transit,filtering peers only,partially safe,6453
 Comcast,ISP,,unsafe,7922
 Deutsche Telekom,ISP,started,unsafe,3320
 Google,cloud,,unsafe,15169
+Hi3G,ISP,,unsafe,44034
 Hurricane Electric,transit,,unsafe,6939
 Level3/CenturyLink,transit,,unsafe,3356
 Orange,transit,started,unsafe,5511
 Sparkle,transit,started,unsafe,6762
 Sprint,transit,,unsafe,1239
+TDC,ISP,,unsafe,3292
 Telefonica/Telxius,transit,,unsafe,12956
 Telstra,transit,,unsafe,4637
 Telxius,transit,started,unsafe,12956


### PR DESCRIPTION
TDC operates brands such as YouSee, Hi3G operates 3 Denmark and 3
Sweden.