### PR TITLE
AT&T filters peers only

### DIFF
--- a/public/data/operators.csv
+++ b/public/data/operators.csv
@@ -1,5 +1,5 @@
 name,type,details,status,asn
-AT&T,ISP,signed + filtering,safe,7018
+AT&T,ISP,signed + filtering peers only,partially safe,7018
 Cloudflare,cloud,signed + filtering,safe,13335
 NTT,transit,signed + filtering,safe,2914
 Telia,transit,signed + filtering,safe,1299


### PR DESCRIPTION
AT&T RPKI filters peers only for now, so it should be going to the partially safe category.

After all the single most important information is whether $network will propagate hijack/leaks or not.