### PR TITLE
Added Telefonica del Peru as well

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -24,3 +24,4 @@ Sprint,transit,,unsafe,1239,34
 Cloudflare,cloud,signed + filtering,safe,13335,1819
 Amazon,cloud,signed,partially safe,16509,3444
 Google,cloud,,unsafe,15169,1714
+Telefonica,ISP,unsafe,AS6147,1815


### PR DESCRIPTION
Added Telefonica del Peru (AS6147), which is not safe as well.