### PR TITLE
Add AS45595 Pakistan Telecom Company Limited (PTCL) in operators

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -87,6 +87,7 @@ Cablenet Cyprus,ISP,signed + filtering,safe,35432,1215
 xneelo,cloud,,unsafe,37153,1233
 HotNet Internet Services,ISP,,unsafe,12849,1257
 Synapsecom Telecoms,cloud,,unsafe,8280,1290
+Pakistan Telecom Company Limited,ISP,,unsafe,45595,1433
 A1 Belarus,ISP,,unsafe,42772,1496
 NetCom BW,ISP,,unsafe,41998,1508
 Continent 8 LLC,cloud,,unsafe,14537,1513


### PR DESCRIPTION
ASN: https://ipinfo.io/AS45595
Tweet: https://twitter.com/armujahid/status/1251561174379966465
ASN rank is 1433: https://asrank.caida.org/asns?asn=45595&type=search