### PR TITLE
remove Init7 twitter handle

### DIFF
--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -30,7 +30,6 @@ asn,handle
 12322,free
 12353,VodafonePT
 12430,vodafone_es
-13030,init7
 15557,SFR
 20001,getspectrum
 20115,getspectrum


### PR DESCRIPTION
Per ISP request. They're small and have committed to deploying origin validation.