### PR TITLE
add Swisscom ISP (AS3303) to the operators list

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -24,3 +24,4 @@ Sprint,transit,,unsafe,1239,34
 Cloudflare,cloud,signed + filtering,safe,13335,1819
 Amazon,cloud,signed,partially safe,16509,3444
 Google,cloud,,unsafe,15169,1714
+Swisscom,ISP,,unsafe,3303,69


### PR DESCRIPTION
Add Swisscom (swiss national ISP) to the list.