### PR TITLE
Add Sunrise Communications AG

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -24,3 +24,4 @@ Sprint,transit,,unsafe,1239,34
 Cloudflare,cloud,signed + filtering,safe,13335,1819
 Amazon,cloud,signed,partially safe,16509,3444
 Google,cloud,,unsafe,15169,1714
+Sunrise Communications AG,ISP,,unsafe,6730,203


### PR DESCRIPTION
Add results of the Is BGP safe yet? test for Sunrise Communications AG (ISP).