### PR TITLE
Add Init7 (Schweiz) AG to operators.csv

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -24,3 +24,4 @@ Sprint,transit,,unsafe,1239,34
 Cloudflare,cloud,signed + filtering,safe,13335,1819
 Amazon,cloud,signed,partially safe,16509,3444
 Google,cloud,,unsafe,15169,1714
+Init7 (Schweiz) AG,ISP,started,unsafe,13030,139


### PR DESCRIPTION
We're signing some prefixes but are waiting for RPKI support in SLXOS to reject invalid prefixes.
So I added us as "started".