### PR TITLE
add two austrian ISPs

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -70,3 +70,5 @@ Turksat,ISP,,unsafe,47524,10355
 Globe Telecom,ISP,,unsafe,132199,10444
 Coextro,ISP,,unsafe,36445,13475
 Millenicom,ISP,,unsafe,34296
+Russmedia IT,ISP,,unsafe,5385
+Magenta (T-Mobile Austria),ISP,,unsafe,8412

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -75,3 +75,5 @@ asn,handle
 134067,unitiwireless
 16591,GoogleFiber
 10139,SMARTCares
+5385,russmediacom
+8412,magentatelekom


### PR DESCRIPTION
 added the two austrian ISPs Russmedia IT, Magenta (T-Mobile Austria)