### PR TITLE
Add KPN-Netco (AS1136)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -45,6 +45,7 @@ Spectrum,ISP,,unsafe,12271,607
 Videotron,ISP,,unsafe,5769,677
 2degrees,ISP,,unsafe,23655,856
 Turknet,ISP,,unsafe,12735,954
+KPN-Netco,ISP,signed,partially safe,1136,593
 HotNet Internet Services,ISP,,unsafe,12849,1257
 NetCom BW,ISP,,unsafe,41998,1508
 A3 Sverige,ISP,,unsafe,45011,1644

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -3,6 +3,7 @@ asn,handle
 701,VERIZON
 812,Rogers
 852,TELUS
+1136,KPN-Netco
 1221,Telstra
 1267,WIND_Telecomunicazioni
 1399,megacable


### PR DESCRIPTION
```diff
+ Correctly accepted valid prefixes
- Incorrectly accepted invalid prefixes
```

Added as `signed` & `partially safe`.
[AS 1136, Rank 593](https://asrank.caida.org/asns?asn=1136&type=search)