### PR TITLE
RPKI configure in Edgeuno network

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -199,7 +199,7 @@ APIK Media,cloud,signed + filtering,safe,58820,2982
 Free SAS,ISP,signed,unsafe,12322,3007
 Bouygues Telecom,ISP,,unsafe,5410,3011
 Triolan,ISP,filtering,partially safe,13188,3056
-EdgeUno,cloud,,unsafe,7195,3160
+EdgeUno,cloud,signed + filtering,safe,7195,3160
 Oy Creanova Hosting Solutions Ltd,cloud,,unsafe,51765,3209
 GSL Networks,cloud,,unsafe,137409,3277
 Amazon,cloud,signed,partially safe,16509,3444


### PR DESCRIPTION
RPKI  configure in Edgeuno network.

![image](https://user-images.githubusercontent.com/61796244/85749690-724f8e00-b6df-11ea-835f-74e2eb5dddc4.png)

The edgeuno is with rpki configured and with drop for all invalid ROA.

dropping on all invalid routes in all countries and for routing peering transit and customers