### PR TITLE
Mark Aussie Broadband AS4764 as safe

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -187,7 +187,7 @@ TheGigabit,cloud,,unsafe,55720,2147
 Netwerkvereniging ColoClue,ISP,signed + filtering,safe,8283,2152
 Microsoft,cloud,,unsafe,8075,2262
 ST-BGP,cloud,,unsafe,46844,2295
-Aussie Broadband,ISP,started,unsafe,4764,2319
+Aussie Broadband,ISP,signed + filtering,safe,4764,2319
 Dhiraagu,ISP,signed + filtering,safe,7642,2357
 MEO Portugal,ISP,,unsafe,3243,2490
 UK-2 Limited,cloud,,unsafe,13213,2517


### PR DESCRIPTION
Aussie Broadband can now be considered safe.

Source: https://whrl.pl/Rf68lz