### PR TITLE
HOPUS (AS44530) is now filtering all eBGP sessions using RPKI ROV.

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -122,6 +122,7 @@ KPN-Netco,ISP,signed,partially safe,1136,593
 Volia,cloud,,unsafe,25229,595
 Spectrum,ISP,,unsafe,12271,607
 Taiwan Fixed Network,ISP,signed,unsafe,9924,613
+HOPUS,transit,signed + filtering,safe,44530,640
 Beltelecom,ISP,,unsafe,6697,658
 Persis Telecom,ISP,signed + filtering,safe,14282,671
 ViewQwest,ISP,signed + filtering,safe,18106,675

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -221,6 +221,7 @@ asn,handle
 42772,a1belarus
 43289,trabia_network
 43350,nforce_bv
+44530,hopusnet
 44944,Telenet
 45011,A3Sverige
 45595,PTCLOfficial


### PR DESCRIPTION
ROA created since 2012-07-01
Filtering all eBGP sessions using RPKI ROV since 2020-09-14 (https://twitter.com/afenioux/status/1305430383345971201).
AS rank : https://asrank.caida.org/asns?asn=44530