### PR TITLE
Revert "Fix NANOG link rot"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -79,7 +79,7 @@
           <li>July 24, 2020 - Telstra AS1221, Australia’s leading telecommunications and technology company, now filters RPKI invalids. (<a href="http://lists.ausnog.net/pipermail/ausnog/2020-July/044367.html">source</a>)
           <li>July 13, 2020 - Chilean Government Network (Red de Conectividad del Estado) at AS17147 succesfully deployed RPKI filtering and drops invalid prefixes. (<a href="https://twitter.com/BenjaMatias/status/1278565243136942081">source</a>)
           <li>July 6, 2020 – GR-IX, the Greek Internet Exchange, is now dropping RPKI invalids on their route servers (<a href="https://www.ripe.net/ripe/mail/archives/connect-wg/2020-July/000109.html">source</a>)
-          <li>June 16, 2020 – Hurricane Electric AS6939, a major transit provider deployed RPKI filters (<a href="https://mailman.nanog.org/pipermail/nanog/2020-June/208043.html">source</a>)
+          <li>June 16, 2020 – Hurricane Electric AS6939, a major transit provider deployed RPKI filters (<a href="https://mailman.nanog.org/pipermail/nanog/2020-June/108277.html">source</a>)
           <li>June 16, 2020 - AnacondaWeb AS265656, an ISP and hosting provider from Temuco (Chile), successfully deployed RPKI signing and filtering. (<a href="https://twitter.com/pcolomes/status/1271336495400574977">source</a>)
           <li>June 5, 2020 – Cogent AS174, the 3rd largest transit provider, now filters all RPKI invalids
           <li>June 1, 2020 – Mobicom, the main transit provider in Mongolia, deployed RPKI (<a href="https://twitter.com/Ulsbold1125/status/1266435596194418689">source</a>)
@@ -96,7 +96,7 @@
           <li>April 24, 2020 – Cyta, a Cyprus ISP, deployed RPKI
           <li>April 23, 2020 – Jaguar Networks, deployed RPKI (<a href="https://twitter.com/JDescoux/status/1253344721201696768">source</a>)
           <li>April 22, 2020 – Scaleway, a cloud provider, deployed RPKI in March 2020 (<a href="https://twitter.com/Scaleway_fr/status/1252941792850382849">source</a>)
-          <li>April 20, 2020 – Gigabit ApS, a Danish ISP, deployed RPKI (<a href="https://mailman.nanog.org/pipermail/nanog/2020-April/207061.html">source</a>)
+          <li>April 20, 2020 – Gigabit ApS, a Danish ISP, deployed RPKI (<a href="https://mailman.nanog.org/pipermail/nanog/2020-April/107295.html">source</a>)
           <li>April 20, 2020 – USI Fiber currently working on RPKI implementation (<a href="https://twitter.com/usifiber/status/1252272488979091457">source</a>)
           <li>April 19, 2020 – Aussie Broadband plans to support RPKI “shortly” (<a href="https://twitter.com/Aussie_BB/status/1252067879358361600">source</a>)
         </ul>


### PR DESCRIPTION
At some point the old links was restored and the new ones was broken, so
let's revert the change.

This reverts commit 80e0bcdf74316116a1aaf61c2ec6004a4aa8ed7b.