### PR TITLE
Adding Nutrien North America (AS393891)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -349,6 +349,7 @@ Kviknet DK,ISP,signed + filtering,safe,204151,21707
 HQserv,cloud,,unsafe,42994,22744
 TL Group,cloud,,safe,263812,24357
 Pacswitch,ISP,filtering,partially safe,55536,27546
+Nutrien,ISP,signed + filtering,safe,393891,28383
 AnacondaWeb,ISP,signed + filtering,safe,265656,32585
 Asimia Damaskou,cloud,,unsafe,205053,36355
 iServer-AS,cloud,,unsafe,57127,36355


### PR DESCRIPTION
Nutrien North America AS393891 (www.nutrien.com), all prefixes signed and dropping invalides.

![image](https://user-images.githubusercontent.com/6805839/103448786-063c7c80-4c64-11eb-8c44-44bf828fbc80.png)

![image](https://user-images.githubusercontent.com/6805839/103448798-2ff5a380-4c64-11eb-9e51-82dcbee6fced.png)

For validation that i am the operator at AS393891, my name and email will be listed on IRR data for both the AS and prefixes.