### PR TITLE
TDC/AS3292 now rejects invalids

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -78,7 +78,7 @@ Vodafone España,ISP,,unsafe,12430,201
 Sunrise Communications AG,ISP,,unsafe,6730,203
 SIA Tet,ISP,,unsafe,12578,205
 Vocus Retail,ISP,signed + filtering,safe,9443,210
-TDC,ISP,,unsafe,3292,222
+TDC,ISP,signed+filtering,safe,3292,286
 Jaguar Network,ISP,signed + filtering,safe,30781,226
 PLDT,ISP,,unsafe,9299,230
 VNPT,cloud,,unsafe,45899,239


### PR DESCRIPTION
All TDC NET DK RIPE prefix ressources has been signed since april 2020.
Rejecting invalids was fully implemented thoughout the network February 24th 2021.

This can be validated using our route-server / looking-glass (find links via PeeringDB.com).

Also stated as a remark in our RIPE aut-num:AS3292 object.


//Output from [https://sg-pub.ripe.net/jasper/rpki-web-test/]:

" a RIPE Labs experiment in collaboration with Job Snijders/NTT

testing valid ROA...[passed]

testing invalid ROA (5sec)...[passed]

Your ASN is AS3292, your prefix is 80.160.0.0/13 and your network is dropping RPKI invalid BGP routes."