### PR TITLE
Update operators.csv

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -191,7 +191,7 @@ TekSavvy,ISP,,unsafe,5645,1727
 SkyCable,ISP,,unsafe,23944,1746
 A2B Internet,ISP,signed + filtering,safe,51088,1755
 Cybernet Pakistan,ISP,,unsafe,9541,1757
-Cloudflare,cloud,signed + filtering,safe,13335,1819
+Cloudflare,cloud,partially signed + filtering,partially safe,13335,1819
 HostDime.com Inc,cloud,,safe,33182,1841
 xs4all,cloud,signed + filtering,safe,3265,1937
 Worldstream,ISP,signed,partially safe,49981,2000


### PR DESCRIPTION
AS13335 is only partially signed.

https://rpki.cloudflare.com/?view=bgp&asn=13335 says that 18% of routes are unsigned, including 2606:4700:f1::/48 (used by time.cloudflare.com) and almost all of 2606:4700:3000::/40 (used by websites on the free plan). It seems incorrect to call the network "signed" or "safe".