### PR TITLE
Updated Comcast status

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -20,7 +20,7 @@ Deutsche Telekom,ISP,started,unsafe,3320,19
 AT&T,ISP,signed + filtering peers only,partially safe,7018,20
 Verizon,ISP,,unsafe,701,21
 Liberty Global,transit,signed + filtering peers only,partially safe,6830,22
-Comcast,ISP,started,unsafe,7922,23
+Comcast,ISP,signed + filtering,safe,7922,23
 SingTel,transit,,unsafe,7473,24
 Algar Telecom,transit,,unsafe,16735,26
 Globenet,transit,,unsafe,52320,32


### PR DESCRIPTION
Comcast has completed dropping invalids on inter-providers sessions and also issuing ROAs to cover its address space.