### PR TITLE
Removed Comcast from example ISPs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,7 +47,7 @@
 
             <p>Unfortunately, it isn’t secure, and there have been some <a href="https://blog.cloudflare.com/how-verizon-and-a-bgp-optimizer-knocked-large-parts-of-the-internet-offline-today/">major Internet disruptions</a> as a result. But fortunately there is a way to make it secure.</p>
 
-            <p>ISPs and other major Internet players (Comcast, Sprint, Verizon, and others) would need to implement a certification system, called <a href="#what-is-rpki">RPKI</a>.</p>
+            <p>ISPs and other major Internet players (Sprint, Verizon, and others) would need to implement a certification system, called <a href="#what-is-rpki">RPKI</a>.</p>
           </div>
 
           <div class="Hero--actions">


### PR DESCRIPTION
The text "ISPs and other major Internet players (Comcast, Sprint, Verizon, and others) would need to implement a certification system..." suggests that these have not done so.   At this point (as of 5/14/2021), Comcast has completed implementing of "filtering and signing".  Hence, the text should be updated.