### PR TITLE
Update operators.csv

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -130,7 +130,7 @@ Elisa Finland,ISP,,unsafe,719,577
 Reliance Jio,ISP,signed,unsafe,55836,584
 KPN-Netco,ISP,signed + filtering,safe,1136,593
 Volia,cloud,,unsafe,25229,595
-Charter,ISP,signed,unsafe,12271,607
+Charter,ISP,signed + filtering,safe,12271,607
 Taiwan Fixed Network,ISP,signed,unsafe,9924,613
 HOPUS,transit,signed + filtering,safe,44530,640
 Beltelecom,ISP,,unsafe,6697,658

--- a/data/operators.csv
+++ b/data/operators.csv
@@ -125,7 +125,7 @@ Elisa Finland,ISP,,unsafe,719,577
 Reliance Jio,ISP,signed,unsafe,55836,584
 KPN-Netco,ISP,signed,partially safe,1136,593
 Volia,cloud,,unsafe,25229,595
-Spectrum,ISP,,unsafe,12271,607
+Charter,ISP,signed,unsafe,12271,607
 Taiwan Fixed Network,ISP,signed,unsafe,9924,613
 HOPUS,transit,signed + filtering,safe,44530,640
 Beltelecom,ISP,,unsafe,6697,658


### PR DESCRIPTION
Changed "Spectrum" to Charter.  Spectrum is the brand name, like "Xfinity" is to Comcast. Added "signed" as we now have all our prefixes signed.  We are in the process of filtering out invalids but we are not finished yet.