### PR TITLE
Add Delta Fiber ISP (AS15435)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -272,7 +272,7 @@ Istanbuldc Veri Merkezi,cloud,,unsafe,197328,6633
 Sprint Personal Communications Systems,transit,,unsafe,10507,6634
 Aura Fiber,ISP,,safe,204274,6735
 Kaisanet Oy,ISP,,unsafe,13170,6773
-DELTA Fiber,ISP,,15435,6903
+DELTA Fiber,ISP,,unsafe,15435,6903
 Phase Layer Global Networks,cloud,,unsafe,51852,6959
 komro GmbH,ISP,signed + filtering,safe,29413,7308
 eSecureData,cloud,signed,unsafe,11831,7324

--- a/data/operators.csv
+++ b/data/operators.csv
@@ -272,6 +272,7 @@ Istanbuldc Veri Merkezi,cloud,,unsafe,197328,6633
 Sprint Personal Communications Systems,transit,,unsafe,10507,6634
 Aura Fiber,ISP,,safe,204274,6735
 Kaisanet Oy,ISP,,unsafe,13170,6773
+DELTA Fiber,ISP,,15435,6903
 Phase Layer Global Networks,cloud,,unsafe,51852,6959
 komro GmbH,ISP,signed + filtering,safe,29413,7308
 eSecureData,cloud,signed,unsafe,11831,7324

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -136,6 +136,7 @@ asn,handle
 14525,StellarTechInc
 14537,Continent8
 15424,ElisaOyj
+15435,deltafiber
 15496,AaltoUniversity
 15517,netstream
 15547,bliblablo_ch


### PR DESCRIPTION
# Added Delta Fiber ISP operator
Delta Fiber failed the BGP test.
![](https://cdn.brammys.com/file/brammys/screenshots/2022/01/z06HRk6HpSbzEQdnH1FKRaHpLj0ILtYqRGDlD0WzGJCvqocvMs5aiQPKBzYpt4RQ.png)

# Added Delta Fiber Twitter
https://twitter.com/deltafiber