### PR TITLE
Use response from invalid fetch to determine ISP

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -193,7 +193,8 @@ const initTesting = () => {
             }, 2 * 1000)
 
             invalidFetch
-              .then(() => {
+              .then(response => response.json())
+              .then(data => {
                 completed = true
                 if (timedOut) return
                 renderFailure(data)


### PR DESCRIPTION
In the case of negative RPKI test (invalid.rpki.cloudflare.com responds successfully), the response of the invalid fetch will be used instead of the valid fetch to determine the ISP (ASN).