### PR TITLE
Add Frontier Communications of America (AS5650)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -79,6 +79,7 @@ Vodafone España,ISP,,unsafe,12430,201
 Sunrise Communications AG,ISP,,unsafe,6730,203
 SIA Tet,ISP,,unsafe,12578,205
 Vocus Retail,ISP,signed + filtering,safe,9443,210
+Frontier Communications of America,ISP,filtering,partially safe,5650,214
 TDC,ISP,signed + filtering,safe,3292,286
 Jaguar Network,ISP,signed + filtering,safe,30781,226
 PLDT,ISP,,unsafe,9299,230

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -62,6 +62,7 @@ asn,handle
 5607,SkyUK
 5610,O2_CZ
 5645,TekSavvyNetwork
+5650,FrontierCorp
 5769,videotron
 6128,Optimum
 6181,CincyBell
@@ -291,7 +292,7 @@ asn,handle
 262287,maxihost
 263812,ipxonnetworks
 264649,nuthost
-265656,AnacondaWeb 
+265656,AnacondaWeb
 393886,Leaseweb
 394256,Tech_Futures
 394380,Leaseweb


### PR DESCRIPTION
This PR adds Frontier Communications (AS5650).

They are filtering invalids (see screenshot), but do not appear to be signing routes: https://rpki.cloudflare.com/?view=bgp&asn=5650

![as5650](https://user-images.githubusercontent.com/3399778/151642268-0486db15-ebda-4b3d-a9df-fb7dbd9980e7.png)