### PR TITLE
Marked Cogeco (AS7992) as safe

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -117,7 +117,6 @@ Psychz Networks,cloud,,unsafe,40676,463
 SuddenLink,ISP,,unsafe,19108,470
 Delta Telecom,cloud,,unsafe,29049,471
 Kyivstar,ISP,,unsafe,15895,477
-Cogeco,ISP,,unsafe,7992,497
 Inferno Communications,transit,signed + filtering,safe,207841,500
 DNA Oyj,ISP,,unsafe,16086,523
 Silknet,ISP,signed,unsafe,35805,543

--- a/data/operators.csv
+++ b/data/operators.csv
@@ -164,6 +164,7 @@ UltraWave Telecom,ISP,signed + filtering,safe,262659,1049
 IBM Cloud,cloud,,unsafe,36351,1062
 PenTeleData,ISP,signed,unsafe,3737,1071
 Selectel Ltd,cloud,,unsafe,49505,1080
+Cogeco,ISP,,safe,7992,1134
 Total Server Solutions,cloud,,unsafe,46562,1139
 noris network AG,ISP,signed + filtering,safe,12337,1156
 IP Converge Data Services Inc.,cloud,,unsafe,23930,1193


### PR DESCRIPTION
Here is the proof
<img width="741" alt="Screenshot of https://isbgpsafeyet.com/ saying "Sucess, Your ISP (Cogeco Cable Canada, AS7992) implements BGP safely. It correctly drops invalid prefixes. " src="https://user-images.githubusercontent.com/58151048/152480532-05b9efab-44e1-4b10-95a1-27d9845980f7.png">
