### PR TITLE
Initially show only first ~3 updates, with toggle button to show/hide all

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -353,6 +353,39 @@ h1, h2 {
 }
 
 
+.Updates {
+  position: relative;
+  overflow: hidden;
+  height: 12.7em;
+}
+
+.Updates[data-show-all="true"] {
+  height: auto;
+}
+
+.Updates::after {
+  content: "";
+  position: absolute;
+  background: var(--background-color);
+  height: 5em;
+  left: 0;
+  right: 0;
+  top: 100%;
+  box-shadow:
+    0 -.5em 1em -.8em rgba(var(--color-rgb), .4),
+    0 -1px 5px -3px var(--color),
+    0 -1px rgba(var(--color-rgb), .4);
+}
+
+.Updates[data-show-all="true"]::after {
+  opacity: 0;
+}
+
+.Updates--actions {
+  text-align: center;
+}
+
+
 .InlineSafeHighlight {
   color: var(--status-green-fg);
   background: var(--status-green-bg);

--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,7 @@
       <div class="Markdown">
         <h2 class="Markdown--h2-as-h3">Latest updates</h2>
 
-        <ul>
+        <ul id="updates" class="Updates" data-js-updates>
           <li>June 27, 2022 - Orange International Carrier (AS5511) has fully deployed RPKI Origin Validation on their global worldwide network. (<a href="https://twitter.com/OrangeIC/status/1541436188241891328">source</a>)
           <li>March 15, 2022 - KPN (AS1136), the largest Internet provider in the Netherlands, now rejects RPKI-invalid BGP routes on its EBGP edge. (<a href="https://twitter.com/JobSnijders/status/1503649158422487040">source</a>)
           <li>June 3, 2021 - NOS Communicações (AS2860), a leading Internet Service Provider in Portugal, has signed its prefixes and is dropping invalids.
@@ -112,6 +112,10 @@
           <li>April 20, 2020 – USI Fiber currently working on RPKI implementation (<a href="https://twitter.com/usifiber/status/1252272488979091457">source</a>)
           <li>April 19, 2020 – Aussie Broadband plans to support RPKI “shortly” (<a href="https://twitter.com/Aussie_BB/status/1252067879358361600">source</a>)
         </ul>
+
+        <div class="Updates--actions">
+          <button class="Button Button-is-secondary Button-is-slim" data-js-toggle-show-all-updates>＋ Show all</button>
+        </div>
       </div>
 
       <div class="Spacer"></div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -18,6 +18,27 @@ const failureMessageDetails = `${ ''
 fetch https://invalid.rpki.cloudflare.com
   <i fail><i>${ svgTimes }</i></i>incorrectly accepted invalid prefixes`
 
+const setupShowAllUpdatesToggle = () => {
+  const updates = document.querySelector('[data-js-updates]')
+  const button = document.querySelector('[data-js-toggle-show-all-updates]')
+
+  if (!updates || !button) return
+
+  button.addEventListener('click', () => {
+    if (updates.getAttribute('data-show-all') === 'true') {
+      updates.setAttribute('data-show-all', 'false')
+      button.textContent = '＋ Show all'
+      requestAnimationFrame(() => {
+        window.scrollTo(0, 0)
+        updates.closest('.Column').scrollIntoView(true)
+      })
+    } else {
+      updates.setAttribute('data-show-all', 'true')
+      button.textContent = '－ Show fewer'
+    }
+  })
+}
+
 const setupShowAllRowsToggle = () => {
   const table = document.querySelector('[data-js-table]')
   const button = document.querySelector('[data-js-toggle-show-all-rows]')
@@ -271,6 +292,7 @@ const openPossibleTargetFAQItem = () => {
 }
 
 const init = () => {
+  setupShowAllUpdatesToggle()
   setupShowAllRowsToggle()
   setupASNColumnToggle()
   initTesting()


### PR DESCRIPTION
Hey 👋 @lspgn and @jejenone! Hope you two are doing well.

When we first designed the site, as you know we didn’t have any news updates. We featured updates at the top due to their recency and thus relevancy. As this update list has grown tall it pushes the Status table very far below the fold, obscuring a core part of the experience, and unnecessarily highlighting updates which are many months old.

I tried to strike a balance by showing roughly the first three updates:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/154613/189500588-fc949e34-6a96-47db-bb51-81ef45460e08.png">

Please let me know your thoughts! Cheers