### PR TITLE
update operators.csv - AS6830 is (now fully) safe

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -19,7 +19,7 @@ TransTelecom,transit,,unsafe,20485,18
 Comcast,ISP,signed + filtering,safe,7922,19
 AT&T,ISP,signed + filtering peers only,partially safe,7018,20
 Verizon,ISP,,unsafe,701,21
-Liberty Global,transit,signed + filtering peers only,partially safe,6830,22
+Liberty Global,transit,signed + filtering,safe,6830,22
 SingTel,transit,,unsafe,7473,24
 Deutsche Telekom,ISP,started,unsafe,3320,25
 Algar Telecom,transit,,unsafe,16735,26


### PR DESCRIPTION
Hi,

AS6830 is filtering IP transit customers nowadays, it is also a member of MANRS, hence it can be listed as "safe".

<img width="1235" alt="Screenshot 2022-12-12 at 17 27 03" src="https://user-images.githubusercontent.com/8971544/207100233-bb81d697-b1f6-45c8-a186-a9b70e3fac30.png">

@jejenone I hope you don't mind drawing your attention on this (I noticed you're a contributor to this repository), would you be so kind to merge this pull request?

Niko