### PR TITLE
Update CI image

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
-      - run: npm install -g markdownlint-cli@0.23.2
+          node-version: '19.x'
+      - run: npm install -g markdownlint-cli@0.33.0
       - run: markdownlint '**/*.md' --ignore node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,6 @@ Create a pull-request.
 We will review it and merge it if it's valid.
 Try to include proof if you're indicating a filtering ISP (mailing-list message, website, tweet, RIPE Atlas test).
 
-If you wish to publish a new major deployment as part of the *latest updates*: edit the following:
+If you wish to publish a new major deployment as part of the _latest updates_: edit the following:
 [index.html](https://github.com/cloudflare/isbgpsafeyet.com/blob/master/src/index.html) [[edit it online](https://github.com/cloudflare/isbgpsafeyet.com/edit/master/src/index.html)]
 Make sure you provide enough information to validate the statement.


### PR DESCRIPTION
We can no-longer find CI instances for `ubuntu-18.04` on GitHub, leaving tests fail for the `lint` job. This PR updates the base image for the job to `ubuntu-latest` and update the nodejs version as well.