### PR TITLE
Fix deprecation warnings and build failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,15 +22,15 @@ jobs:
     - name: Build Workers script
       run: npm run build-worker
       env:
-        CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
     - name: Wrangler auth check
-      run: wrangler whoami
+      run: npm run wrangler-whoami
       env:
-        CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
     - name: Upload assets
       run: npm run deploy-worker
       env:
-        CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "deploy-worker": "wrangler publish --env production",
     "webpack-dev": "webpack-cli -w ",
     "wrangler-dev": "wrangler dev",
+    "wrangler-whoami": "wrangler whoami",
     "start": "concurrently --kill-others-on-fail --names 'webpack ,wrangler' --prefix name --prefix-colors 'bgCyan.black,bgYellow.black' \"npm run webpack-dev\" \"npm run wrangler-dev\" \"while ! nc -z localhost 8787; do\nsleep 1\ndone; open 'http://localhost:8787'\"",
     "test": "jest",
     "lint-markdown": "markdownlint '**/*.md' --ignore node_modules --ignore dist"


### PR DESCRIPTION
Replaces the deprecated CF_* environment variables with their CLOUDFLARE_* counterparts.

Fixes the deployment build by always calling wrangler with an npm script instead of calling it directly.