### PR TITLE
Fix text overlap in the status table

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -13,7 +13,7 @@ html {
   --line-height: 1.7;
   --color-rgb: var(--gray-1-rgb);
   --accent-color-rgb: var(--indigo-3-rgb);
-  --column-width: 42rem;
+  --column-width: 45rem;
   --column-inline-padding: 1rem;
 }
 
@@ -450,10 +450,10 @@ h1, h2 {
   border-spacing: 0;
   border: 0;
 
-  --type-column-width: 6rem;
-  --details-column-width: 14rem;
+  --type-column-width: 5rem;
+  --details-column-width: 18rem;
   --status-column-width: 8rem;
-  --asn-column-width: 7rem;
+  --asn-column-width: 6rem;
 
   --non-name-columns-width-sum: calc(
     var(--type-column-width) +


### PR DESCRIPTION
This PR fixes the text overlap that can be seen in the following capture, by widening the page a bit and tweaking the width of some of the columns.

<img width="897" alt="image" src="https://github.com/cloudflare/isbgpsafeyet.com/assets/937276/843e07c8-cf28-4ccf-8b80-8323c2277b17">
