### PR TITLE
Fixed casing of label for AS52863 (UPX TECNOLOGIA)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -400,7 +400,7 @@ TELUS Communications,ISP,signed + filtering,safe,852,166
 Bristol Bay Telephone Coop,ISP,signed + filtering,safe,397388,74134
 Advanced Wireless Network Co. Ltd.,ISP,signed,unsafe,133481,74135
 Netinternet,cloud,signed + filtering,safe,51559,2136
-UPX TECNOLOGIA,transit,signed + filtering,Safe,52863,338
+UPX TECNOLOGIA,transit,signed + filtering,safe,52863,338
 Ursin Filli,ISP,signed + filtering,safe,202427,75328
 Rose Telecom,ISP,signed + filtering,safe,54681,24936
 Bryan Barbolina trading as Cloudwebservices,cloud,signed + filtering,safe,213268,65065


### PR DESCRIPTION
In #657, AS52863's label was mistakenly added as 'Safe' instead of 'safe', putting it above all other operators in the status list regardless of its AS rank:
![Screenshot of isbgpsafeyet.com showing UPX TECNOLOGIA at the top of the list with the label of 'Safe'.](https://github.com/cloudflare/isbgpsafeyet.com/assets/11741772/6b77e4e3-1edd-4be5-86f9-cd11619de6d3)

This PR lowercases the label. Corrected effects can be seen on [this Worker](https://isbgpsafeyet.kockaadmiralac.workers.dev/):
![Screenshot of isbgpsafeyet.kockaadmiralac.workers.dev no longer showing UPX TECNOLOGIA at the top of the list.](https://github.com/cloudflare/isbgpsafeyet.com/assets/11741772/3478e1a1-89ab-4e02-a898-685dcfb521e8)

The AS Rank of the mentioned AS has been updated in the meantime, but I did not touch it in this PR as there seem to be many other ASes with outdated ranks in the CSV file.