### PR TITLE
Update operators.csv

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -138,6 +138,7 @@ Elisa Finland,ISP,,unsafe,719,577
 Reliance Jio,ISP,signed,unsafe,55836,584
 KPN-Netco,ISP,signed + filtering,safe,1136,593
 Volia,cloud,,unsafe,25229,595
+Optimum (formerly Suddenlink),ISP,,unsafe,19108,606
 Charter,ISP,signed + filtering,safe,12271,607
 Taiwan Fixed Network,ISP,signed,unsafe,9924,613
 HOPUS,transit,signed + filtering,safe,44530,640


### PR DESCRIPTION
Part of Optimum’s footprint was formerly known as Suddenlink.

The AS rank obtained was from https://asrank.caida.org/.