### PR TITLE
Add latest update for Verizon (AS701)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -71,6 +71,7 @@
         <h2 class="Markdown--h2-as-h3">Latest updates</h2>
 
         <ul id="updates" class="Updates" data-js-updates>
+          <li>January 24, 2024 - Verizon (AS701) one of the largest ISPs in the US, has fully deployed RPKI Origin Validation across their network.</li>
           <li>April 5, 2023 - Liberty Global (AS6830) One of the largest ISPs in Europe, now filters RPKI-OV invalid routes on its EBGP edge. (<a href="https://twitter.com/libertyglobal/status/1643542432573800451?s=20">source</a>)
           <li>October 19, 2022 - Microsoft (AS8075) has deployed RPKI Origin Validation on all their peers. (<a href="https://storage.googleapis.com/site-media-prod/meetings/NANOG86/4602/20221017_Robachevsky_Internet_Routing_And_v1.pdf">source</a>)
           <li>June 27, 2022 - Orange International Carrier (AS5511) has fully deployed RPKI Origin Validation on their global worldwide network. (<a href="https://twitter.com/OrangeIC/status/1541436188241891328">source</a>)


### PR DESCRIPTION
Add latest updates entry for Verizon (AS701) start filtering RPKI invalid routes.