### PR TITLE
Add AS19879 (prev. AS44658)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -423,3 +423,4 @@ Kerfuffle,Cloud,signed + filtering,safe,35008,11481
 Rozint Ltd Co,ISP,signed + filtering,safe,21738,2442
 MilkyWan,ISP,signed + filtering,safe,2027,1829
 Telekom Malaysia Berhad,ISP,signed,unsafe,4788,114
+Propel,cloud,signed + filtering,safe,19879,59398


### PR DESCRIPTION
Propel / AS19879 (prev. AS44658) filters RPKI OV invalids since 2024-07-01