### PR TITLE
Explicit disable (unsafe) `X-XSS-Protection`-header

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -96,7 +96,7 @@ async function handleEvent(event) {
     if (url.pathname === '/' || url.pathname === '/index.html') {
       response.headers.set('Cache-Control', 'public; max-age=60')
       response.headers.set('Content-Security-Policy', "default-src 'none'; script-src 'self' data: 'unsafe-inline'; object-src 'none'; style-src 'self' ui.components.workers.dev; img-src 'self'; media-src 'none'; frame-src 'none'; font-src 'none'; connect-src 'self' invalid.rpki.isbgpsafeyet.com valid.rpki.isbgpsafeyet.com")
-      response.headers.set('X-XSS-Protection', '1; mode=block')
+      response.headers.set('X-XSS-Protection', '0')
       response.headers.set('X-Frame-Options', 'DENY')
       response.headers.set('Referrer-Policy', 'unsafe-url')
 


### PR DESCRIPTION
A bit counter-intuitive, but `X-XSS-Protection` is actually dangerous on (old) browsers supporting the spec.

In _filtering_ mode it easily allows attackers to remove critical blocks of JavaScript, which can introduce vulnerabilities in otherwise safe code: [PoC](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection#vulnerabilities_caused_by_xss_filtering).

In _blocking_ mode it can be used as an side-channel oracle, leaking cross origin bodies/tokens: [theory](https://portswigger.net/research/abusing-chromes-xss-auditor-to-steal-tokens) / [PoC](https://www.youtube.com/watch?v=HcrQy0C-hEA)

Hot take, this is a terrible header that shouldn't be included.  In this PR I explicit disable it, but this PR could also easily be refactored to completely remove the header.

Disabling it on modern browsers does nothing, as it is already disabled.