### PR TITLE
Add AS8881 - 1&1 Versatel

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -426,3 +426,4 @@ Kerfuffle,Cloud,signed + filtering,safe,35008,11481
 Rozint Ltd Co,ISP,signed + filtering,safe,21738,2442
 MilkyWan,ISP,signed + filtering,safe,2027,1829
 Telekom Malaysia Berhad,ISP,signed,unsafe,4788,114
+1&1 Versatel,ISP,partially signed,unsafe,8881,220


### PR DESCRIPTION
Add german ISP 1&1 to the operators list
https://asrank.caida.org/asns?asn=as8881&type=search
https://radar.cloudflare.com/routing/as8881

It appears they signed most of their routes (some remain unknown)
I couldn't detect any filtering on https://isbgpsafeyet.com/ and was able to reach https://invalid.rpki.cloudflare.com
I also ran https://rpkitest.nlnetlabs.net/ and it failed for both ipv4 and ipv6.

I ran all tests over DSL as well as cellular for this ISP.
I could provide screenshots if required.