### PR TITLE
Add AS8560 - IONOS SE

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -426,3 +426,4 @@ Kerfuffle,Cloud,signed + filtering,safe,35008,11481
 Rozint Ltd Co,ISP,signed + filtering,safe,21738,2442
 MilkyWan,ISP,signed + filtering,safe,2027,1829
 Telekom Malaysia Berhad,ISP,signed,unsafe,4788,114
+IONOS SE,Cloud,signed + filtering,safe,8560,838


### PR DESCRIPTION
Add german hoster IONOS to the operators list (belongs to ISP 1&1 - see #753)
https://asrank.caida.org/asns?asn=8560&type=search
https://radar.cloudflare.com/routing/as8560
https://bgp.he.net/AS8560

It appears they sign all of their routes (1 unknown or so)
I was able to ping valid.rpki.isbgpsafeyet.com and wasn't able to ping invalid.rpki.isbgpsafeyet.com (I tested ipv4 and ipv6 individually)
I was able to ping valid.rpki.cloudflare.com and wasn't able to ping invalid.rpki.cloudflare.com (I tested ipv4 and ipv6 individually)

They clearly filter invalid routes since mid of november last year
https://stats.labs.apnic.net/rpki/AS8560