### PR TITLE
Update AS1239 - T-Mobile

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -35,7 +35,7 @@ SingTel,transit,,unsafe,7473,24
 Deutsche Telekom,ISP,signed + filtering,safe,3320,25
 Algar Telecom,transit,,unsafe,16735,26
 Globenet,transit,,unsafe,52320,32
-T-Mobile,transit,filtering,safe,1239,32
+T-Mobile,transit,partially signed + filtering,safe,1239,98
 KPN,transit,signed + filtering,safe,286,36
 Telefonica Vivo,transit,,unsafe,10429,39
 Internexa,transit,,unsafe,262589,40


### PR DESCRIPTION
They are still filtering https://stats.labs.apnic.net/rpki/AS1239
They are partially signed now https://radar.cloudflare.com/routing/as1239
Their rank dropped to 98 https://asrank.caida.org/asns?asn=1239&type=search