### PR TITLE
AS2856 (British Telecom) started (or better)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -87,7 +87,7 @@ TIM,ISP,,unsafe,3269,176
 AAPT Limited,ISP,,unsafe,2764,181
 TELY,transit,,unsafe,53087,188
 Rogers,ISP,started,unsafe,812,198
-British Telecommunications,ISP,,unsafe,2856,199
+British Telecommunications,ISP,,started,2856,199
 Vodafone España,ISP,,unsafe,12430,201
 Sunrise Communications AG,ISP,,unsafe,6730,203
 SIA Tet,ISP,,unsafe,12578,205


### PR DESCRIPTION
isbgpsafeyet.com report:

Your ISP (BTnet (BT's UK IP Network - AS2856), AS2856) implements BGP safely. It correctly drops invalid prefixes.

Details

fetch https://valid.rpki.isbgpsafeyet.com
  correctly accepted valid prefixes

fetch https://invalid.rpki.isbgpsafeyet.com
  correctly rejected invalid prefix