### PR TITLE
Mark AS7018 as safe

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -28,7 +28,7 @@ Telefonica/Telxius,transit,signed + filtering,safe,12956,16
 PJSC RosTelecom,transit,,unsafe,12389,17
 TransTelecom,transit,,unsafe,20485,18
 Comcast,ISP,signed + filtering,safe,7922,19
-AT&T,ISP,signed + filtering peers only,partially safe,7018,20
+AT&T,ISP,signed + filtering,safe,7018,20
 Verizon,ISP,signed + filtering,safe,701,21
 Liberty Global,transit,signed + filtering,safe,6830,22
 SingTel,transit,,unsafe,7473,24


### PR DESCRIPTION
Data suggests AT&T (AS7018) is fully filtering RPKI invalids now: https://stats.labs.apnic.net/rpki/AS7018?a=&c=&ll=0&ss=0&mm=1&vv=0&w=7

![image](https://github.com/user-attachments/assets/038e3deb-fceb-466d-b8cc-51dbb38f05b2)

Related issue: #771 