### PR TITLE
Update operators.csv

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -435,3 +435,5 @@ IONOS SE,Cloud,signed + filtering,safe,8560,838
 Inter.link,transit,signed + filtering,safe,5405,83
 SysEleven,transit,signed + filtering,safe,25291,1618
 TelHi Corporation (Infal),ISP,signed + filtering,safe,150369,2195
+Bharat Sanchar Nigam Limited (BSNL),ISP,,unsafe,9829,
+BHARTI Airtel Ltd.,ISP,,unsafe,9498,


### PR DESCRIPTION
Added BSNL 9829 and Bharti Airtel 9498 as unsafe.

The below link the evidences -- 
https://lg.ring.nlnog.net/prefix?saved=AMJU0GnQkA 