### PR TITLE
Added AS19468 (Valex Cloud LLC) as safe (Full RPKI Filtering on ALL BGP Routers)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -435,3 +435,4 @@ IONOS SE,Cloud,signed + filtering,safe,8560,838
 Inter.link,transit,signed + filtering,safe,5405,83
 SysEleven,transit,signed + filtering,safe,25291,1618
 TelHi Corporation (Infal),ISP,signed + filtering,safe,150369,2195
+Valex Cloud LLC (VALEX),ISP,signed + filtering,safe,19468,66787


### PR DESCRIPTION
Added AS19468 (Valex Cloud LLC) as safe (Full RPKI Filtering on ALL BGP Routers)
ASN Ranking for AS19468 Pulled from https://asrank.caida.org/