### PR TITLE
Mark AS577 as safe

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -62,7 +62,7 @@ Seabras,transit,,unsafe,13786,83
 SK Broadband,ISP,,unsafe,9318,85
 TPG,ISP,,unsafe,7545,87
 Durand,transit,,unsafe,22356,88
-Bell Canada,ISP,,unsafe,577,90
+Bell Canada,ISP,signed + filtering,safe,577,126
 IIJ,transit,signed + filtering peers only,partially safe,2497,95
 Orange Polska,ISP,signed + filtering,safe,5617,96
 Optimum,ISP,,unsafe,6128,97

--- a/src/index.html
+++ b/src/index.html
@@ -71,6 +71,7 @@
         <h2 class="Markdown--h2-as-h3">Latest updates</h2>
 
         <ul id="updates" class="Updates" data-js-updates>
+          <li>August 28, 2025 - Bell Canada (AS577) One of the largest ISPs in Canada, now filters RPKI invalid routes received by its network (<a href="https://github.com/cloudflare/isbgpsafeyet.com/pull/808">source</a>.
           <li>Febrary 22, 2024 - Deutsche Telekom (AS3320) One of the largest ISPs in Europe, now filters RPKI invalid routes received by its global network. (<a href="https://globalcarrier.telekom.com/newsroom/news/news-pages/deutsche-telekom-global-carrier-enhances-global-internet-security">source</a>)
           <li>January 24, 2024 - Verizon (AS701) one of the largest ISPs in the US, has fully deployed RPKI Origin Validation across their network.</li>
           <li>April 5, 2023 - Liberty Global (AS6830) One of the largest ISPs in Europe, now filters RPKI-OV invalid routes on its EBGP edge. (<a href="https://twitter.com/libertyglobal/status/1643542432573800451?s=20">source</a>)


### PR DESCRIPTION
The change rolled out around July 17, 2025.
<img width="1482" height="987" alt="image" src="https://github.com/user-attachments/assets/a5d116c8-39f5-45c6-8c1f-7d204caf334b" />


Related issue: #804 