### PR TITLE
 Add Tele2 and remove Comhem

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -90,6 +90,7 @@ SIA Tet,ISP,,unsafe,12578,205
 OCN,ISP,signed + filtering peers only,partially safe,4713,207
 Init7 (Schweiz) AG,ISP,signed,unsafe,13030,208
 Vocus Retail,ISP,signed + filtering,safe,9443,210
+Tele2 Sverige AB,ISP,,safe,1257,211
 1&1 Versatel,ISP,partially signed,unsafe,8881,220
 Jaguar Network,ISP,signed + filtering,safe,30781,226
 PLDT,ISP,,unsafe,9299,230
@@ -459,7 +460,6 @@ Bristol Bay Telephone Coop,ISP,signed + filtering,safe,397388,74134
 Advanced Wireless Network Co. Ltd.,ISP,signed,unsafe,133481,74135
 NNET,ISP,signed + filtering,safe,142582,74809
 Ursin Filli,ISP,signed + filtering,safe,202427,75328
-ComHemAB,ISP,,unsafe,39651,77693
 de.theirs,ISP,signed + filtering,safe,200242,77721
 VDX Networks,ISP,signed + filtering,safe,208723,77796
 AR Informatik AG (Kanton Appenzell Ausserrhoden),ISP,signed + filtering,safe,211452,77797

--- a/data/twitter.csv
+++ b/data/twitter.csv
@@ -21,6 +21,7 @@ asn,handle
 852,TELUS
 1136,KPN
 1221,Telstra
+1257,Tele2 Sverige AB
 1267,WIND_Telecomunicazioni
 1399,megacable
 1741,CSCfi
@@ -238,7 +239,6 @@ asn,handle
 37611,Afrihost
 37705,Topnet_FSI
 38195,Superloopnet
-39651,ComHemAB
 39699,LouneaOy
 39857,AaltoUniversity
 40676,PsychzNetworks


### PR DESCRIPTION
Adding my home ISP, [Tele2](https://www.tele2.se/), ([asrank](https://asrank.caida.org/asns?asn=1257&type=search))

Proof:
<img width="886" height="756" alt="image" src="https://github.com/user-attachments/assets/56fe5ffa-c4a0-44a5-a783-7605099f0fd1" />


ComHem doesn't exist any more after it was bought up by Tele2. [Here](https://www.tele2.com/media/news/2021/mobile-broadband-and-entertainment-converges-in-one-brand-as-com-hem-becomes-tele2/) is the press release when the merger was done.
