### PR TITLE
Add Telefonica Germany GmbH & Co.OHG (AS6805)

### DIFF
--- a/data/operators.csv
+++ b/data/operators.csv
@@ -246,6 +246,7 @@ Netwerkvereniging ColoClue,ISP,signed + filtering,safe,8283,2152
 TNG Stadtnetz GmbH,ISP,signed + filtering,safe,13101,2174
 TelHi Corporation (Infal),ISP,signed + filtering,safe,150369,2195
 TOT-NET,ISP,,unsafe,23969,2198
+Telefónica Germany GmbH & Co. OHG,ISP,signed,unsafe,6805,2257
 ST-BGP,cloud,,unsafe,46844,2295
 Aussie Broadband,ISP,signed + filtering,safe,4764,2319
 Dhiraagu,ISP,signed + filtering,safe,7642,2357


### PR DESCRIPTION
<img width="1548" height="686" alt="image" src="https://github.com/user-attachments/assets/e7b0fb28-92c2-4419-9224-f65945a18c8f" />

## Prefixes Signed

Source: https://rpki-validator.ripe.net/ui/?prefix=&include=related_alloc%2Crelated_asn&asns=AS6805
<img width="1552" height="3316" alt="image" src="https://github.com/user-attachments/assets/7798c8c4-7de1-4c0e-af20-a521aa04fba5" />

## Partially Filtered (0% < I-RoV Filtering < 100 %) - Current: 0.72%

Source: https://stats.labs.apnic.net/rpki/AS6805?a=6805&c=DE&ll=1&ss=1&mm=1&vv=0&w=7&s=0
<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/3ba978e7-df18-4999-9000-dd1e0cc0a6f6" />

Interestingly, https://rpkitest.nlnetlabs.net/ shows full pass:

<img width="2940" height="1902" alt="image" src="https://github.com/user-attachments/assets/5eaa5a8a-4c87-4bd0-ac48-b8394305be49" />

## ASRank

Unfortunately, [asrank.caida.org](https://asrank.caida.org/asns?asn=6805&type=search) fails with a 500 Internal Server error, so i used the rank from [archive.org](https://web.archive.org/web/20251215105601/https://asrank.caida.org/asns/6805)